### PR TITLE
Fix some automotive audio issues

### DIFF
--- a/audio/configs/audio_platform_info.xml
+++ b/audio/configs/audio_platform_info.xml
@@ -108,6 +108,7 @@
         <device name="SND_DEVICE_OUT_LOOPBACK_HANDSET_DUAL_MIC" interface="INT0_MI2S_RX"/>
 
         <device name="SND_DEVICE_OUT_SPEAKER" backend="speaker" interface="SEC_MI2S_RX"/>
+        <device name="SND_DEVICE_OUT_VOICE_SPEAKER_HFP" backend="speaker" interface="SEC_MI2S_RX"/>
         <device name="SND_DEVICE_OUT_SPEAKER_CALIBRATION" backend="speaker" interface="SEC_MI2S_RX"/>
         <device name="SND_DEVICE_OUT_SPEAKER2" backend="speaker" interface="SEC_MI2S_RX"/>
         <device name="SND_DEVICE_OUT_CALL_SPEAKER" backend="speaker" interface="SEC_MI2S_RX"/>
@@ -238,6 +239,7 @@
         <device name="SND_DEVICE_OUT_VOICE_HEARING_AID" backend="hearing-aid" interface="BT_RX"/>
 
         <device name="SND_DEVICE_IN_REC_MAIN_MIC" interface="INT3_MI2S_TX"/>
+        <device name="SND_DEVICE_IN_VOICE_SPEAKER_MIC_HFP" interface="INT3_MI2S_TX"/>
         <device name="SND_DEVICE_IN_REC_HEADSET_MAIN_MIC" interface="INT3_MI2S_TX"/>
         <device name="SND_DEVICE_IN_REC_STEREO_MIC_JAM" interface="INT3_MI2S_TX"/>
         <device name="SND_DEVICE_IN_REC_STEREO_MIC" interface="INT3_MI2S_TX"/>

--- a/audio/configs/audio_platform_info.xml
+++ b/audio/configs/audio_platform_info.xml
@@ -443,8 +443,10 @@
         <usecase name="USECASE_AUDIO_PLAYBACK_SILENCE" type="out" id="27" />
         <usecase name="USECASE_AUDIO_PLAYBACK_MMAP" type="out" id="33" />
         <usecase name="USECASE_AUDIO_RECORD_MMAP" type="in" id="33" />
-        <usecase name="USECASE_AUDIO_HFP_SCO" type="in" id="35" />
-        <usecase name="USECASE_AUDIO_HFP_SCO_WB" type="in" id="35" />
+        <usecase name="USECASE_AUDIO_HFP_SCO" type="in" id="12" />
+        <usecase name="USECASE_AUDIO_HFP_SCO_WB" type="in" id="12" />
+        <usecase name="USECASE_AUDIO_HFP_SCO" type="out" id="40" />
+        <usecase name="USECASE_AUDIO_HFP_SCO_WB" type="out" id="40" />
         <usecase name="USECASE_AUDIO_PLAYBACK_VOIP" type="out" id="16" />
         <usecase name="USECASE_AUDIO_RECORD_VOIP" type="in" id="16" />
         <usecase name="USECASE_AUDIO_A2DP_ABR_FEEDBACK" type="in" id="35" />
@@ -471,8 +473,8 @@
         <param key="true_32_bit" value="true"/>
         <!-- In the below value string, the value indicates sidetone gain in dB -->
         <param key="usb_sidetone_gain" value="35"/>
-        <param key="hfp_pcm_dev_id" value="36"/>
         <param key="hifi_filter" value="false"/>
+        <param key="hfp_pcm_dev_id" value="39"/>
     </config_params>
 
     <gain_db_to_level_mapping>

--- a/audio/configs/mixer_paths.xml
+++ b/audio/configs/mixer_paths.xml
@@ -1717,17 +1717,38 @@
     </path>
 
     <path name="hfp-sco">
-   </path>
-
-    <path name="hfp-sco headphones">
+        <ctl name="HFP_SLIM7_UL_HL Switch" value="1" />
+        <ctl name="INT0_MI2S_RX Port Mixer SLIM_7_TX" value="1" />
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia6" value="1" />
+        <ctl name="MultiMedia6 Mixer INT3_MI2S_TX" value="1" />
+        <ctl name="INT0_MI2S_RX_DL_HL Switch" value="1" />
     </path>
 
-   <path name="hfp-sco-wb">
+    <path name="hfp-sco headphones">
         <path name="hfp-sco" />
-   </path>
+    </path>
+
+    <path name="hfp-sco speaker">
+        <ctl name="HFP_SLIM7_UL_HL Switch" value="1" />
+        <ctl name="SEC_TDM_RX_0 Port Mixer SLIM_7_TX" value="1" />
+        <ctl name="SLIMBUS_7_RX Audio Mixer MultiMedia6" value="1" />
+        <ctl name="MultiMedia6 Mixer INT3_MI2S_TX" value="1" />
+        <ctl name="SEC_TDM_RX_0_DL_HL Switch" value="1" />
+    </path>
+
+    <path name="hfp-sco-wb">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="hfp-sco" />
+    </path>
 
     <path name="hfp-sco-wb headphones">
+        <ctl name="BT SampleRate" value="KHZ_16" />
         <path name="hfp-sco headphones" />
+    </path>
+
+    <path name="hfp-sco-wb speaker">
+        <ctl name="BT SampleRate" value="KHZ_16" />
+        <path name="hfp-sco speaker" />
     </path>
 
     <path name="compress-voip-call">

--- a/audio/configs/mixer_paths.xml
+++ b/audio/configs/mixer_paths.xml
@@ -2496,6 +2496,10 @@
         <ctl name="FL Digital PCM Volume" value="817" />
     </path>
 
+    <path name="voice-speaker-hfp">
+        <path name="call-speaker" />
+    </path>
+
     <path name="call-dual-speaker">
         <path name="dual-spk" />
     </path>
@@ -2556,6 +2560,10 @@
 		<ctl name="DEC1 Volume" value="92" />
         <ctl name="ADC3 Volume" value="2" />
         <ctl name="DEC2 Volume" value="92" />
+    </path>
+
+    <path name="voice-speaker-mic-hfp">
+        <path name="call-speaker-mic" />
     </path>
 
     <path name="handset-mic">

--- a/bluetooth/bdroid_buildcfg.h
+++ b/bluetooth/bdroid_buildcfg.h
@@ -25,6 +25,9 @@
 
 #define BTM_DEF_LOCAL_NAME "Galaxy Tab S5e"
 
+/* Enable A2DP sink */
+#define BTA_AV_SINK_INCLUDED TRUE
+
 #define BLE_VND_INCLUDED   TRUE
 #define BTIF_HF_WBS_PREFERRED TRUE
 #define BTM_WBS_INCLUDED TRUE

--- a/overlay/packages/apps/Bluetooth/res/values/config.xml
+++ b/overlay/packages/apps/Bluetooth/res/values/config.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) 2014, The Linux Foundation. All rights reserved.
+
+     Redistribution and use in source and binary forms, with or without
+     modification, are permitted (subject to the limitations in the
+     disclaimer below) provided that the following conditions are met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+        * Neither the name of the Linux Foundation nor the names of its
+          contributors may be used to endorse or promote products derived
+          from this software without specific prior written permission.
+
+     NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+     GRANTED BY THIS LICENSE.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+     HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+     WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+     MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+     LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+     CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+     SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+     BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+     WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+     OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+     IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+<resources>
+    <!-- If true, device requests audio focus and start avrcp updates on source start or play -->
+    <bool name="a2dp_sink_automatically_request_audio_focus">true</bool>
+</resources>


### PR DESCRIPTION
* Enable A2DP sink in Bluedroid
* Add mixer paths for HFP usecase and fix PCM device IDs
* Enable a2dp_sink_automatically_request_audio_focus config